### PR TITLE
docker-compose エイリアスを新しい docker compose コマンドに更新

### DIFF
--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -1,6 +1,6 @@
 # docker
 alias d="docker"
-alias dc="docker-compose"
+alias dc="docker compose"
 
 docker() {
   case $1 in


### PR DESCRIPTION
## 概要
Docker Composeのエイリアスを、非推奨の `docker-compose` コマンドから新しい `docker compose` サブコマンドに更新しました。

## 変更内容
- `dc` エイリアスを `docker-compose` から `docker compose` に変更

## 変更の理由
Dockerは、独立したバイナリである `docker-compose` コマンドを非推奨とし、Dockerの組み込みサブコマンドである `docker compose` の使用を推奨しています。この変更により、docker-composeが個別にインストールされていない新しいDocker環境でも互換性が確保されます。

## 影響範囲
zshでDockerを使用する際の `dc` エイリアスの挙動が変更されます。機能的な違いはありません。