### PR TITLE
/Users/yukio-goto/.localのパスサポートを追加

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -16,3 +16,11 @@ for plugin ($ZSH_EXT_BASE/plugins/*) {
 
 # add local_tools at the top of PATH
 export PATH=/opt/local_tools:$PATH
+
+if [ -d $HOME/.local/bin ]; then
+  export PATH=$HOME/.local/bin:$PATH
+fi
+
+if [ -d $HOME/.local/share/zsh/site-functions ]; then
+  fpath=($HOME/.local/share/zsh/site-functions $fpath)
+fi


### PR DESCRIPTION
## 概要

`$HOME/.local/bin` と `$HOME/.local/share/zsh/site-functions` のパス設定を追加します。

## 変更内容

- `$HOME/.local/bin` をPATHに追加（ディレクトリが存在する場合）
- `$HOME/.local/share/zsh/site-functions` をfpathに追加（ディレクトリが存在する場合）

## 理由

- uvなどの多くのツールやパッケージが `$HOME/.local/bin` にバイナリをインストールする
- zshの補完ファイルが `$HOME/.local/share/zsh/site-functions` によくインストールされる
- これらのパスを含めることで、ツールと補完が正しく機能するようになる

## テスト

- ディレクトリが存在する場合のみパスを追加するため、存在しない場合もエラーは発生しない