### PR TITLE
fzf-tab プラグインを追加

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "plugins/zsh-syntax-highlighting"]
 	path = plugins/zsh-syntax-highlighting
 	url = https://github.com/zsh-users/zsh-syntax-highlighting.git
+[submodule "plugins/fzf-tab"]
+	path = plugins/fzf-tab
+	url = https://github.com/byplayer/fzf-tab.git


### PR DESCRIPTION
## 概要

zsh のタブ補完に fuzzy-finding 機能を提供する fzf-tab プラグインを追加しました。

## 変更内容

- fzf-tab プラグインを git submodule として追加
- `.gitmodules` に fzf-tab の設定を追加

## 効果

タブ補完時に fuzzy-finding が利用できるようになり、長いリストから選択する際のユーザー体験が向上します。