### PR TITLE
✨ Add fzf-action plugin for enhanced completion

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "plugins/fzf-tab"]
 	path = plugins/fzf-tab
 	url = https://github.com/byplayer/fzf-tab.git
+[submodule "plugins/fzf-action"]
+	path = plugins/fzf-action
+	url = https://github.com/byplayer/fzf-action.git

--- a/lib/fzf-action.zsh
+++ b/lib/fzf-action.zsh
@@ -1,0 +1,2 @@
+bindkey '^gr' fzf-action-git-branches-all
+bindkey '^gb' fzf-action-git-branches

--- a/lib/zaw.zsh
+++ b/lib/zaw.zsh
@@ -1,6 +1,6 @@
 bindkey '^gz' zaw
-bindkey '^gr' zaw-git-recent-all-branches
-bindkey '^gb' zaw-git-recent-branches
+# bindkey '^gr' zaw-git-recent-all-branches
+# bindkey '^gb' zaw-git-recent-branches
 bindkey '^gs' zaw-git-status-edit
 bindkey '^gf' zaw-git-files
 bindkey '^gw' zaw-git-worktree


### PR DESCRIPTION
## Summary

Add the fzf-action plugin as a new submodule to provide enhanced git branch selection functionality with better interactive experience.

## Changes

- Added `fzf-action` plugin as a git submodule
- Created `lib/fzf-action.zsh` with keyboard shortcuts:
  - `^gr`: fzf-action for all branches
  - `^gb`: fzf-action for current branches
- Disabled conflicting `zaw` keybindings for the same shortcuts

## Motivation

The fzf-action plugin offers a cleaner and more intuitive interface for git branch selection compared to the current zaw-based implementation.