### PR TITLE
Update fzf-action keybindings and configuration

### DIFF
--- a/lib/fzf-action.zsh
+++ b/lib/fzf-action.zsh
@@ -1,2 +1,5 @@
+export FZF_ACTION_EDITOR='code'
+
 bindkey '^gr' fzf-action-git-branches-all
 bindkey '^gb' fzf-action-git-branches
+bindkey '^gf' fzf-action-git-files

--- a/lib/zaw.zsh
+++ b/lib/zaw.zsh
@@ -2,7 +2,7 @@ bindkey '^gz' zaw
 # bindkey '^gr' zaw-git-recent-all-branches
 # bindkey '^gb' zaw-git-recent-branches
 bindkey '^gs' zaw-git-status-edit
-bindkey '^gf' zaw-git-files
+# bindkey '^gf' zaw-git-files
 bindkey '^gw' zaw-git-worktree
 
 export ZAW_EDITOR='code'


### PR DESCRIPTION
## Summary

Updated fzf-action plugin keybindings and configuration to migrate git-files functionality from zaw to fzf-action.

## Changes

- Added `FZF_ACTION_EDITOR` environment variable to set VS Code as the default editor
- Reassigned `^gf` keybinding from `zaw-git-files` to `fzf-action-git-files`
- Updated fzf-action submodule to the latest version

## Motivation

Migrating from zaw's git-files functionality to fzf-action's git-files provides a more consistent interface for file navigation.

## Impact

- Zsh keybinding configuration
- fzf-action plugin behavior