### PR TITLE
Migrate command history feature to fzf-action

### DIFF
--- a/lib/fzf-action.zsh
+++ b/lib/fzf-action.zsh
@@ -5,6 +5,7 @@ bindkey '^gb' fzf-action-git-branches
 bindkey '^gf' fzf-action-git-files
 bindkey '^gs' fzf-action-git-status-edit-mode
 bindkey '^gw' fzf-action-git-worktree
+bindkey '^r' fzf-action-command-history
 
 # _fzf-format-worktree-entry - Format a worktree entry for display
 # Arguments:

--- a/lib/fzf.zsh
+++ b/lib/fzf.zsh
@@ -51,26 +51,6 @@ function fzf-cdr () {
 zle -N fzf-cdr
 bindkey "^gc" fzf-cdr
 
-# CTRL-R - Paste the selected command from history into the command line
-fzf-history-widget() {
-  local selected num
-  setopt localoptions noglobsubst noposixbuiltins pipefail 2> /dev/null
-  selected=( $(fc -rl 1 |
-    FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS --query=${(qqq)LBUFFER} +m" $(__fzfcmd)) )
-  local ret=$?
-  if [ -n "$selected" ]; then
-    num=$selected[1]
-    if [ -n "$num" ]; then
-      zle vi-fetch-history -n $num
-      zle accept-line
-    fi
-  fi
-  zle reset-prompt
-  return $ret
-}
-zle     -N   fzf-history-widget
-bindkey '^R' fzf-history-widget
-
 # overwite to add accept-line and preview option
 __fzf_generic_path_completion() {
   local base lbuf compgen fzf_opts suffix tail fzf dir leftover matches


### PR DESCRIPTION
## Overview

Migrated the command history feature to the fzf-action plugin to centralize fzf-related functionality and reduce code duplication.

## Changes

- Removed the local `fzf-history-widget` function from `lib/fzf.zsh`
- Updated fzf-action submodule to version with command history support
- Changed `^r` keybinding to use `fzf-action-command-history`

## Motivation

Centralizing fzf-related functionality improves maintainability and eliminates code duplication.

## Impact

The command history search feature (`Ctrl+R`) implementation has changed, but the user operation remains the same.