### PR TITLE
fzf-actionに履歴制限の設定機能を追加

### DIFF
--- a/lib/fzf-action.zsh
+++ b/lib/fzf-action.zsh
@@ -7,6 +7,8 @@ bindkey '^gs' fzf-action-git-status-edit-mode
 bindkey '^gw' fzf-action-git-worktree
 bindkey '^r' fzf-action-command-history
 
+export FZF_ACTION_HISTORY_LIMIT=30000
+
 # _fzf-format-worktree-entry - Format a worktree entry for display
 # Arguments:
 #   $1 - path: Full path to the worktree


### PR DESCRIPTION
## 概要

fzf-actionの履歴表示において、履歴件数を制限できる環境変数 `FZF_ACTION_HISTORY_LIMIT` を追加しました。

## 変更内容

- `FZF_ACTION_HISTORY_LIMIT` 環境変数を追加（デフォルト値: 30000）
- lib/fzf-action.zsh の初期化時にこの環境変数をエクスポート

## 変更理由

履歴が大量にある場合のパフォーマンス改善と、ユーザーが必要に応じて履歴の表示件数を調整できるようにするため。デフォルト値の30000は、包括的な履歴アクセスとパフォーマンスのバランスを考慮して設定しています。

## 影響範囲

- この環境変数は、fzf-actionの履歴機能で使用されることを想定しています
- 既存の動作に影響はありません（環境変数が設定されていない場合、各機能は従来通りの動作をします）