### PR TITLE
ls abbreviationに--quieterと--forceオプションを追加

### DIFF
--- a/lib_after_plugin/misc.zsh
+++ b/lib_after_plugin/misc.zsh
@@ -68,7 +68,7 @@ EZA_COLORS+=":*.bk=38;5;245"
 EZA_COLORS+=":tm=38;5;245"
 export EZA_COLORS
 
-abbr -S --quiet ls="eza -g --icons --git"
+abbr -S --quiet --quieter --force ls="eza -g --icons --git"
 
 abbr -S --quiet cd_gtop='cd `git top`'
 


### PR DESCRIPTION
## Summary

ls abbreviation（`abbr -S --quiet ls="eza -g --icons --git"`）に `--quieter` と `--force` オプションを追加しました。

### 変更内容

- `--quieter`: 警告メッセージをさらに抑制
- `--force`: 既存の略語を強制的に上書き

これにより、シェル起動時に既存の略語に関する警告が表示されなくなり、より静かに動作します。