### PR TITLE
Enhance zsh-abbr prefix patterns and add scalar prefixes

### DIFF
--- a/lib_after_plugin/misc.zsh
+++ b/lib_after_plugin/misc.zsh
@@ -86,9 +86,16 @@ function ymd_date() {
 export PATH=/opt/emacs/bin:${PATH}
 
 ABBR_REGULAR_ABBREVIATION_GLOB_PREFIXES+=(
+  ' '
   '*& '
   '*&& '
-  '*| '
-  '*|| '
+  '*[|] '
+  '*[|][|] '
   '*; '
+  '[A-Z]*=* '
+)
+
+ABBR_REGULAR_ABBREVIATION_SCALAR_PREFIXES+=(
+  'watch ' 'which ' 'sudo '
+  'env ' 'time ' 'nice ' 'nohup '
 )


### PR DESCRIPTION
## Overview

Enhanced the abbreviation expansion behavior by extending prefix patterns and adding scalar prefix support for zsh-abbr.

## Changes

### Extended Glob Prefixes
- Added space-only pattern
- Added environment variable pattern (`[A-Z]*=* `)
- Fixed pipe character escaping (`'*| '` → `'*[|] '`)

### Added Scalar Prefixes
Abbreviations now expand correctly after these command wrappers:
- `watch`
- `which`
- `sudo`
- `env`
- `time`
- `nice`
- `nohup`

## Effects

With these changes, abbreviations will expand correctly in cases like:
```bash
# After environment variable assignment
ENV_VAR=value <abbreviation>

# With command wrappers
sudo <abbreviation>
watch <abbreviation>

# After pipes and semicolons
command | <abbreviation>
command ; <abbreviation>
```

## Testing

- [ ] Verified by reloading zsh in local environment
- [ ] Confirmed abbreviations expand with each prefix pattern