### PR TITLE
fzf-ag の省略形を ag から fag に変更

### DIFF
--- a/lib_after_plugin/fzf.zsh
+++ b/lib_after_plugin/fzf.zsh
@@ -129,4 +129,4 @@ function fzf-ag () {
     code -g ${file}:${line}
   fi
 }
-abbr -S --quiet ag=fzf-ag
+abbr -S --quiet fag=fzf-ag


### PR DESCRIPTION
## 概要
zsh-abbr の省略形を `ag` から `fag` に変更しました。

## 変更理由
`ag` は silver searcher コマンドと名前が衝突するため、より明確な `fag` (fzf-ag の頭文字) に変更しました。

## 変更内容
- `lib_after_plugin/fzf.zsh`: abbr の定義を `ag=fzf-ag` から `fag=fzf-ag` に変更