### PR TITLE
Revert zsh-abbr functionality and restore aliases

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "plugins/fzf-action"]
 	path = plugins/fzf-action
 	url = https://github.com/byplayer/fzf-action.git
-[submodule "pre_plugins/zsh-abbr"]
-	path = pre_plugins/zsh-abbr
-	url = https://github.com/olets/zsh-abbr

--- a/init.sh
+++ b/init.sh
@@ -4,27 +4,17 @@ autoload -U compinit
 compinit -i
 
 # TIP: Add files you don't want in git to .gitignore
-for config_file ("$ZSH_EXT_BASE"/lib/*.zsh) {
-  source "$config_file"
-}
+for config_file ($ZSH_EXT_BASE/lib/*.zsh) source $config_file
 
 # load plugins
-for plugin ("$ZSH_EXT_BASE"/pre_plugins/*) {
-  plugin_name=$(basename "$plugin")
-  if [ -f "$ZSH_EXT_BASE/pre_plugins/$plugin_name/$plugin_name.plugin.zsh" ]; then
-    source "$ZSH_EXT_BASE/pre_plugins/$plugin_name/$plugin_name.plugin.zsh"
+for plugin ($ZSH_EXT_BASE/plugins/*) {
+  plugin_name=`basename $plugin`
+  if [ -f $ZSH_EXT_BASE/plugins/$plugin_name/$plugin_name.plugin.zsh ]; then
+    source $ZSH_EXT_BASE/plugins/$plugin_name/$plugin_name.plugin.zsh
   fi
 }
 
-# load plugins
-for plugin ("$ZSH_EXT_BASE"/plugins/*) {
-  plugin_name=$(basename "$plugin")
-  if [ -f "$ZSH_EXT_BASE/plugins/$plugin_name/$plugin_name.plugin.zsh" ]; then
-    source "$ZSH_EXT_BASE/plugins/$plugin_name/$plugin_name.plugin.zsh"
-  fi
-}
-
-for config_file ("$ZSH_EXT_BASE"/lib_after_plugin/*.zsh) source "$config_file"
+for config_file ($ZSH_EXT_BASE/lib_after_plugin/*.zsh) source $config_file
 
 # add local_tools at the top of PATH
 export PATH=/opt/local_tools:$PATH

--- a/lib/editor.zsh
+++ b/lib/editor.zsh
@@ -1,9 +1,28 @@
 # emacs config
+# alias emacs='XMODIERS="@im=none" LC_CTYPE="ja_JP.utf8" emacs 2>/dev/null'
+
+
+alias ec="emacsclient"
+
+function ecn {
+    local args
+
+    if [[ $# -eq 2 ]]; then
+        args="+$2 $1"
+    else
+        args=`echo $1 | sed -E "s/([^:]+):([0-9:]+)/+\2 \1/g"`
+    fi
+
+    eval "emacsclient -n $args"
+}
+
 case ${OSTYPE} in
   darwin*)
-    export EDITOR="code --wait"
+    export EDITOR"=code --wait"
+    alias emacs='open -a /Applications/Emacs.app'
     ;;
   *)
+    alias emacs='XMODFIERS="@im=none" emacs 2>/dev/null'
     export EDITOR="code --wait"
     ;;
 esac

--- a/lib/fzf.zsh
+++ b/lib/fzf.zsh
@@ -90,7 +90,7 @@ __fzf_generic_path_completion() {
 # git log command
 fzf-git-log ()
 {
-  git lg | \
+  git lg | emojify | \
    fzf --ansi --no-sort --reverse --tiebreak=index --preview \
    'f() { set -- $(echo -- "$@" | grep -o "[a-f0-9]\{7\}"); [ $# -eq 0 ] || git show --color=always $1 ; }; f {}' \
    --bind "j:down,k:up,alt-j:preview-down,alt-k:preview-up,ctrl-f:preview-page-down,ctrl-b:preview-page-up,q:abort,ctrl-m:execute:
@@ -102,7 +102,7 @@ fzf-git-log ()
 
 fzf-git-log-all ()
 {
-  git lga | \
+  git lga | emojify | \
    fzf --ansi --no-sort --reverse --tiebreak=index --preview \
    'f() { set -- $(echo -- "$@" | grep -o "[a-f0-9]\{7\}"); [ $# -eq 0 ] || git show --color=always $1 ; }; f {}' \
    --bind "j:down,k:up,alt-j:preview-down,alt-k:preview-up,ctrl-f:preview-page-down,ctrl-b:preview-page-up,q:abort,ctrl-m:execute:
@@ -112,8 +112,8 @@ fzf-git-log-all ()
     FZF-EOF" --preview-window=down:60%
 }
 
-abbr -S --quiet glg=fzf-git-log
-abbr -S --quiet glga=fzf-git-log-all
+alias glg=fzf-git-log
+alias glga=fzf-git-log
 
 # ag + fzf
 function fzf-ag () {
@@ -129,4 +129,4 @@ function fzf-ag () {
     code -g ${file}:${line}
   fi
 }
-abbr -S --quiet ag=fzf-ag
+alias fag=fzf-ag

--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -68,12 +68,12 @@ EZA_COLORS+=":*.bk=38;5;245"
 EZA_COLORS+=":tm=38;5;245"
 export EZA_COLORS
 
-abbr -S --quiet ls="eza -g --icons --git"
+alias ls="eza -g --icons --git"
 
-abbr -S --quiet cd_gtop='cd `git top`'
+alias cd_gtop='cd `git top`'
 
 # tmux
-abbr -S --quiet tmux="tmux -2"
+alias tmux="tmux -2"
 
 # add path private scripts
 export PATH=~/.bin:$PATH
@@ -84,11 +84,3 @@ function ymd_date() {
 
 # use custom emacs
 export PATH=/opt/emacs/bin:${PATH}
-
-ABBR_REGULAR_ABBREVIATION_GLOB_PREFIXES+=(
-  '*& '
-  '*&& '
-  '*| '
-  '*|| '
-  '*; '
-)

--- a/lib/ruby.zsh
+++ b/lib/ruby.zsh
@@ -1,0 +1,8 @@
+#ruby_tool
+export PATH=/opt/ruby_tool/bin:$PATH
+
+# ruby aliases
+alias r="rails"
+alias be="bundle exec"
+alias berails="bundle exec rails"
+alias berake="bundle exec rake"

--- a/lib_after_plugin/fzf.zsh
+++ b/lib_after_plugin/fzf.zsh
@@ -129,4 +129,4 @@ function fzf-ag () {
     code -g ${file}:${line}
   fi
 }
-abbr -S --quiet fag=fzf-ag
+abbr -S --quiet ag=fzf-ag

--- a/lib_after_plugin/misc.zsh
+++ b/lib_after_plugin/misc.zsh
@@ -68,7 +68,7 @@ EZA_COLORS+=":*.bk=38;5;245"
 EZA_COLORS+=":tm=38;5;245"
 export EZA_COLORS
 
-abbr -S --quiet --quieter --force ls="eza -g --icons --git"
+abbr -S --quiet ls="eza -g --icons --git"
 
 abbr -S --quiet cd_gtop='cd `git top`'
 

--- a/lib_after_plugin/misc.zsh
+++ b/lib_after_plugin/misc.zsh
@@ -86,16 +86,9 @@ function ymd_date() {
 export PATH=/opt/emacs/bin:${PATH}
 
 ABBR_REGULAR_ABBREVIATION_GLOB_PREFIXES+=(
-  ' '
   '*& '
   '*&& '
-  '*[|] '
-  '*[|][|] '
+  '*| '
+  '*|| '
   '*; '
-  '[A-Z]*=* '
-)
-
-ABBR_REGULAR_ABBREVIATION_SCALAR_PREFIXES+=(
-  'watch ' 'which ' 'sudo '
-  'env ' 'time ' 'nice ' 'nohup '
 )

--- a/lib_after_plugin/ruby.zsh
+++ b/lib_after_plugin/ruby.zsh
@@ -1,8 +1,0 @@
-#ruby_tool
-export PATH=/opt/ruby_tool/bin:$PATH
-
-# ruby aliases
-abbr -S --quiet r="rails"
-abbr -S --quiet be="bundle exec"
-abbr -S --quiet berails="bundle exec rails"
-abbr -S --quiet berake="bundle exec rake"

--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -1,17 +1,61 @@
 # docker
-abbr -S --quiet d="docker"
-abbr -S --quiet --quieter --force dc="docker compose"
-abbr -S --quiet "docker i.l.a"="docker image ls --all"
-abbr -S --quiet "docker i.l"="docker image ls"
-abbr -S --quiet "docker i.p"="docker image prune"
-abbr -S --quiet "docker i.r"="docker image rm"
-abbr -S --quiet "docker i"="docker image"
-abbr -S --quiet "docker c.l.a"="docker container ls --all"
-abbr -S --quiet "docker c.l"="docker container ls"
-abbr -S --quiet "docker c.p"="docker container prune"
-abbr -S --quiet "docker c.r"="docker container rm"
-abbr -S --quiet "docker c"="docker container"
-abbr -S --quiet "docker v"="docker volume"
-abbr -S --quiet "docker v.l"="docker volume ls"
-abbr -S --quiet "docker v.p"="docker volume prune"
-abbr -S --quiet "docker v.r"="docker volume rm"
+alias d="docker"
+alias dc="docker compose"
+
+docker() {
+  case $1 in
+  i.l.a)
+    shift
+    command docker image ls --all "$@"
+    ;;
+  i.l)
+    shift
+    command docker image ls "$@"
+    ;;
+  i.p)
+    shift
+    command docker image prune "$@"
+    ;;
+  i.r)
+    shift
+    command docker image rm "$@"
+    ;;
+  i)
+    shift
+    command docker image "$@"
+    ;;
+  c.l.a)
+    shift
+    command docker container ls --all "$@"
+    ;;
+  c.l)
+    shift
+    command docker container ls "$@"
+    ;;
+  c.p)
+    shift
+    command docker container prune "$@"
+    ;;
+  c.r)
+    shift
+    command docker container rm "$@"
+    ;;
+  c)
+    shift
+    command docker container "$@"
+    ;;
+  v)
+    shift
+    command docker volume "$@"
+    ;;
+  v.l)
+    shift
+    command docker volume ls "$@"
+    ;;
+  *)
+    command docker "$@"
+    ;;
+  esac
+}
+
+dalias() { alias | grep 'docker' | sed "s/^\([^=]*\)=\(.*\)/\1 => \2/" | sed "s/['|\']//g" | sort; }

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -1,42 +1,7 @@
 # git env
 export PATH=/opt/git/bin:/opt/git/contrib/diff-highlight:~/.git-extensions/bin:$PATH
 export MANPATH=/opt/git/share/man:`manpath -q`
-
-# abbreviations for git
-abbr -S --quiet "git br"="git branch"
-abbr -S --quiet "git chp"="git cherry-pick"
-abbr -S --quiet "git ci"="git commit"
-abbr -S --quiet "git cia"="git commit --amend"
-abbr -S --quiet "git co"="git checkout"
-abbr -S --quiet "git d"="git diff"
-abbr -S --quiet "git dc"="git diff --check"
-abbr -S --quiet "git dname"="git diff --name-only"
-abbr -S --quiet "git dns"="git diff --name-status"
-abbr -S --quiet "git ds"="git diff --stat"
-abbr -S --quiet "git dt"="git difftool"
-abbr -S --quiet "git dmb"='git diff $(git merge-base develop HEAD)'
-abbr -S --quiet "git dw"="git diff --color-words"
-abbr -S --quiet "git l"="git log --color"
-abbr -S --quiet "git lg"="git log --graph --pretty=format:'%C(yellow)%h%C(green)%d%Creset %s %Cblue[%ad]%C(bold blue)<%an>%Creset' --abbrev-commit --date=short --branches --color"
-abbr -S --quiet "git lga"="git log --graph --pretty=format:'%C(yellow)%h%C(green)%d%Creset %s %Cblue[%ad]%C(bold blue)<%an>%Creset' --abbrev-commit --date=short --branches --all --color"
-abbr -S --quiet "git lo"="git log --oneline --color"
-abbr -S --quiet "git mg"="git merge"
-abbr -S --quiet "git mt"="git mergetool"
-abbr -S --quiet "git r.p.o"="git remote prune origin"
-abbr -S --quiet "git r.p"="git remote prune"
-abbr -S --quiet "git r.s.o"="git remote show origin"
-abbr -S --quiet "git r.s"="git remote show"
-abbr -S --quiet "git sm"="git submodule"
-abbr -S --quiet "git st"="git status"
-abbr -S --quiet "git sw"="git switch"
-abbr -S --quiet "git swc"="git switch -c"
-abbr -S --quiet "git tags"="git tag -s"
-abbr -S --quiet "git top"="git rev-parse --show-toplevel"
-abbr -S --quiet "git wt.l"="git worktree list"
-abbr -S --quiet "git wt.p"="git worktree prune -v"
-abbr -S --quiet "git wt.r"="git worktree remove"
-abbr -S --quiet "git wt"="git worktree"
-abbr -S --quiet g="git"
+alias g="git"
 
 case ${OSTYPE} in
   darwin*)


### PR DESCRIPTION
## Summary

Remove the zsh-abbr plugin and revert abbreviations back to traditional aliases.

## Changes

- Remove zsh-abbr submodule
- Remove `pre_plugins` directory processing
- Convert abbreviations (`abbr -S`) to `alias`
- Move files from `lib_after_plugin/` to `lib/`
  - `fzf.zsh`
  - `misc.zsh`
  - `ruby.zsh`
- Simplify plugin loading logic in `init.sh`
- Change docker plugin dot notation (e.g., `docker i.l.a`) to function format

## Reason

Revert the zsh-abbr functionality that was added in multiple PRs (#16, #17, #18, #20).

## Impact

- zsh startup behavior
- Command aliases in general
- Docker command shorthand notation