### PR TITLE
Remove emojify command from fzf git log functions

### DIFF
--- a/lib/fzf.zsh
+++ b/lib/fzf.zsh
@@ -90,7 +90,7 @@ __fzf_generic_path_completion() {
 # git log command
 fzf-git-log ()
 {
-  git lg | emojify | \
+  git lg | \
    fzf --ansi --no-sort --reverse --tiebreak=index --preview \
    'f() { set -- $(echo -- "$@" | grep -o "[a-f0-9]\{7\}"); [ $# -eq 0 ] || git show --color=always $1 ; }; f {}' \
    --bind "j:down,k:up,alt-j:preview-down,alt-k:preview-up,ctrl-f:preview-page-down,ctrl-b:preview-page-up,q:abort,ctrl-m:execute:
@@ -102,7 +102,7 @@ fzf-git-log ()
 
 fzf-git-log-all ()
 {
-  git lga | emojify | \
+  git lga | \
    fzf --ansi --no-sort --reverse --tiebreak=index --preview \
    'f() { set -- $(echo -- "$@" | grep -o "[a-f0-9]\{7\}"); [ $# -eq 0 ] || git show --color=always $1 ; }; f {}' \
    --bind "j:down,k:up,alt-j:preview-down,alt-k:preview-up,ctrl-f:preview-page-down,ctrl-b:preview-page-up,q:abort,ctrl-m:execute:


### PR DESCRIPTION
## Summary

Removed the `emojify` command calls from fzf git log functions.

## Changes

- `fzf-git-log` function: `git lg | emojify |` → `git lg |`
- `fzf-git-log-all` function: `git lga | emojify |` → `git lga |`

## Reason

The `emojify` command is no longer necessary for git log display. Removing it simplifies the pipeline and reduces dependencies.

## Impact

Git log output will be displayed directly in fzf.