### PR TITLE
シェル起動高速化とgit-worktree-runner補完追加

### DIFF
--- a/lib/10_asdf.zsh
+++ b/lib/10_asdf.zsh
@@ -1,4 +1,4 @@
 type brew >/dev/null
 if [ $? -eq 0 ]; then
-    export PATH="$(brew --prefix asdf)/bin:${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
+    export PATH="${HOMEBREW_PREFIX}/bin:${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 fi

--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -37,14 +37,14 @@ export TERM=xterm-256color
 # alias 設定
 case ${OSTYPE} in
 darwin*)
-  export PATH=$(brew --prefix coreutils)/libexec/gnubin/:$PATH
-  export MANPATH=$(brew --prefix coreutils)/libexec/gnuman:$MANPATH
-  export PATH=$(brew --prefix findutils)/libexec/gnubin:$PATH
-  export PATH=$(brew --prefix grep)/libexec/gnubin:$PATH
-  export PATH=$(brew --prefix make)/libexec/gnubin:$PATH
-  export PATH=$(brew --prefix gcc)/bin:$PATH
-  export PATH=$(brew --prefix mysql@8.0)/bin:$PATH
-  fpath=($(brew --prefix)/share/zsh/site-functions $fpath)
+  export PATH=${HOMEBREW_PREFIX}/opt/coreutils/libexec/gnubin/:$PATH
+  export MANPATH=${HOMEBREW_PREFIX}/opt/coreutils/libexec/gnuman:$MANPATH
+  export PATH=${HOMEBREW_PREFIX}/opt/findutils/libexec/gnubin:$PATH
+  export PATH=${HOMEBREW_PREFIX}/opt/grep/libexec/gnubin:$PATH
+  export PATH=${HOMEBREW_PREFIX}/opt/make/libexec/gnubin:$PATH
+  export PATH=${HOMEBREW_PREFIX}/opt/gcc/bin:$PATH
+  export PATH=${HOMEBREW_PREFIX}/opt/mysql@8.0/bin:$PATH
+  fpath=(${HOMEBREW_PREFIX}/share/zsh/site-functions $fpath)
   ;;
 esac
 

--- a/lib_after_plugin/git-gtr.zsh
+++ b/lib_after_plugin/git-gtr.zsh
@@ -1,0 +1,4 @@
+fpath=($HOME/.local/share/git-worktree-runner/completions $fpath)
+source $HOME/.local/share/git-worktree-runner/completions/_git-gtr
+
+compdef _git-gtr git-gtr gtr

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -5,7 +5,7 @@ alias g="git"
 
 case ${OSTYPE} in
   darwin*)
-    export PATH=$(brew --prefix git)/share/git-core/contrib/diff-highlight:$PATH
+    export PATH=${HOMEBREW_PREFIX}/opt/git/share/git-core/contrib/diff-highlight:$PATH
     ;;
 esac
 

--- a/plugins/llvm_homebrew/llvm_homebrew.plugin.zsh
+++ b/plugins/llvm_homebrew/llvm_homebrew.plugin.zsh
@@ -1,5 +1,5 @@
 case ${OSTYPE} in
 darwin*)
-    export PATH=$(brew --prefix llvm)/bin:$PATH
+    export PATH=${HOMEBREW_PREFIX}/opt/llvm/bin:$PATH
     ;;
 esac


### PR DESCRIPTION
## 概要

シェル起動時のパフォーマンス改善と、git-worktree-runner (gtr) の補完機能を追加します。

## 変更内容

### 1. 🏎️ Homebrew プレフィックスの最適化

`$(brew --prefix ...)` コマンドをシェル起動時に実行する代わりに、`${HOMEBREW_PREFIX}` 環境変数を直接参照するように変更しました。

**対象ファイル:**
- `lib/10_asdf.zsh`
- `lib/misc.zsh`
- `plugins/git/git.plugin.zsh`
- `plugins/llvm_homebrew/llvm_homebrew.plugin.zsh`

**効果:**
- サブシェル実行を削減し、シェル起動時間を短縮

### 2. ✨ git-worktree-runner 補完サポート追加

git-worktree-runner (git-gtr/gtr) コマンドの補完機能を追加しました。

**追加ファイル:**
- `lib_after_plugin/git-gtr.zsh`