### PR TITLE
trashプラグインでHOMEBREW_PREFIX環境変数を使用

### DIFF
--- a/plugins/trash/trash.plugin.zsh
+++ b/plugins/trash/trash.plugin.zsh
@@ -1,6 +1,6 @@
 case ${OSTYPE} in
 darwin*)
-    export PATH=$(brew --prefix trash)/bin:$PATH
+    export PATH=${HOMEBREW_PREFIX}/opt/trash/bin:$PATH
     alias rm="trash"
     ;;
 esac


### PR DESCRIPTION
## 概要

trashプラグインで `brew --prefix trash` コマンドの代わりに `HOMEBREW_PREFIX` 環境変数を使用するように変更しました。

## 変更内容

- `$(brew --prefix trash)/bin` を `${HOMEBREW_PREFIX}/opt/trash/bin` に置き換え

## 変更理由

シェル起動時のパフォーマンス向上のため、サブシェルで `brew --prefix` コマンドを実行する代わりに、既に設定されている `HOMEBREW_PREFIX` 環境変数を直接使用します。

この変更は bc71b1a での同様の変更と一貫性があります。