### PR TITLE
git-gtr補完設定を削除

### DIFF
--- a/lib_after_plugin/git-gtr.zsh
+++ b/lib_after_plugin/git-gtr.zsh
@@ -1,4 +1,0 @@
-fpath=($HOME/.local/share/git-worktree-runner/completions $fpath)
-source $HOME/.local/share/git-worktree-runner/completions/_git-gtr
-
-compdef _git-gtr git-gtr gtr


### PR DESCRIPTION
## 概要

git-worktree-runner (gtr)の補完設定ファイルを削除します。

## 変更内容

- `lib_after_plugin/git-gtr.zsh` を削除
  - git-gtrの補完設定を読み込むファイル
  - 現在は不要になったため削除

## 削除されたファイルの内容

```zsh
fpath=($HOME/.local/share/git-worktree-runner/completions $fpath)
source $HOME/.local/share/git-worktree-runner/completions/_git-gtr

compdef _git-gtr git-gtr gtr
```