### PR TITLE
Claude Code ステータスラインの設定を追加

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -84,3 +84,6 @@ function ymd_date() {
 
 # use custom emacs
 export PATH=/opt/emacs/bin:${PATH}
+
+# claude
+export CC_STATUSLINE_NO_MODEL=1


### PR DESCRIPTION
## 概要

Claude Code のステータスラインでモデル名を非表示にする環境変数 `CC_STATUSLINE_NO_MODEL=1` を `lib/misc.zsh` に追加します。

## 変更内容

- `lib/misc.zsh` に `CC_STATUSLINE_NO_MODEL=1` 環境変数を追加
- ターミナルのステータスライン表示をクリーンに保つための設定