### PR TITLE
worktree削除時にブランチ未マージの警告を追加

### DIFF
--- a/lib_after_plugin/fzf-action.zsh
+++ b/lib_after_plugin/fzf-action.zsh
@@ -278,6 +278,19 @@ function _fzf-validate-worktree() {
         fi
     fi
 
+    # Check if branch is merged into the default branch
+    local branch_name="$(git -C "$worktree_path" branch --show-current 2>/dev/null)"
+    if [[ -n "$branch_name" ]]; then
+        local default_branch="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')"
+        if [[ -z "$default_branch" ]]; then
+            default_branch="main"
+        fi
+        if ! git merge-base --is-ancestor "$branch_name" "$default_branch" 2>/dev/null; then
+            print "Warning: Branch '$branch_name' is not merged into '$default_branch'"
+            return 1
+        fi
+    fi
+
     return 0
 }
 


### PR DESCRIPTION
## Summary

worktree削除時に、ブランチがデフォルトブランチにマージされていない場合に警告を表示し、削除をブロックするようにしました。

## Changes

- `_fzf-validate-worktree` 関数にマージ済みチェックを追加
- `git merge-base --is-ancestor` を使用してブランチがデフォルトブランチにマージ済みか確認
- デフォルトブランチは `refs/remotes/origin/HEAD` から検出（フォールバック: `main`）
- 未マージの場合は警告メッセージを表示し削除を防止
- `fzf-action-git-worktree-delete` と `fzf-action-git-worktree-delete-with-branch` の両方に適用

## Why

worktree削除時に、マージされていないブランチの作業を誤って失うリスクがありました。この変更により、未マージの作業がある場合に事前に警告されます。