### PR TITLE
Add copy_basename function

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -82,6 +82,15 @@ function ymd_date() {
   date +%Y%m%d
 }
 
+function copy_basename() {
+  emulate -L zsh
+  local url="$1"
+  local path="${url%%\?*}"
+  local copy_name="${path##*/}"
+  printf '%s' "$copy_name" | /usr/bin/pbcopy
+  print -r -- "copied: $copy_name"
+}
+
 # use custom emacs
 export PATH=/opt/emacs/bin:${PATH}
 


### PR DESCRIPTION
## Summary

Added a zsh function `copy_basename` to `lib/misc.zsh` that copies the last path segment of a URL (e.g. a JIRA ticket ID) to the clipboard.

## Example

\`\`\`zsh
copy_basename http://example.com/abc-123
\`\`\`

## Implementation notes

- Strips the query string (\`?...\`) before extracting the basename.
- Uses zsh parameter expansion (\`\${path##*/}\`) to avoid depending on external \`basename\` / \`tr\`.
- Invokes \`pbcopy\` via its absolute path \`/usr/bin/pbcopy\` so it is unaffected by \`PATH\`.
- Prints \`copied: <name>\` to stdout so it is easy to confirm what was copied.