### PR TITLE
Skip reset-prompt while user is typing (async RPROMPT via zle -F)

### DIFF
--- a/lib/prompt.zsh
+++ b/lib/prompt.zsh
@@ -1,10 +1,15 @@
 autoload -Uz add-zsh-hook
+zmodload zsh/system 2> /dev/null
 
 # for async update right prompt
 mkdir -p ${TMPPREFIX}
 
 RPROMPT_WORK_FNAME=zsh_prompt_hook.$$
 RPROMPT_WORK=${TMPPREFIX}/${RPROMPT_WORK_FNAME}
+
+# FD for zle-based async notification. zle -F callbacks run in widget
+# context, so $BUFFER / $KEYMAP are accessible there (unlike TRAPUSR2).
+typeset -g _prompt_async_fd=${_prompt_async_fd:-}
 
 function _prompt_is_in_git {
   if git rev-parse 2> /dev/null; then
@@ -76,12 +81,53 @@ function _git_stat_update {
     echo -n "%F{${VC_UNPUSHED_FG}}$(_prompt_git_not_pushed)" >> ${RPROMPT_WORK}
     echo "%F{${RPROMPT_FG_COLOR}}:%(4~,%-1~/.../%2~,%~)]%f" >> ${RPROMPT_WORK}
 
-    kill -s USR2 $$
+    # Notify parent via inherited FD (replaces kill -USR2).
+    [[ -n $_prompt_async_fd ]] && print -n -u $_prompt_async_fd x 2> /dev/null
+  fi
+}
+
+function _prompt_async_setup {
+  # Already set up and FD still valid
+  [[ -n $_prompt_async_fd ]] && [[ -e /dev/fd/$_prompt_async_fd ]] && return
+
+  local fifo=${TMPPREFIX}/zsh_prompt_async.$$
+  command rm -f $fifo
+  mkfifo $fifo 2> /dev/null || return 1
+
+  # Open read+write so the FD never sees EOF across child writes.
+  exec {_prompt_async_fd}<> $fifo
+  command rm -f $fifo
+
+  zle -F $_prompt_async_fd _prompt_async_callback
+}
+
+function _prompt_async_callback {
+  local fd=$1 discard
+
+  # Drain any buffered notification bytes non-blockingly.
+  while sysread -t 0 -i $fd discard 2> /dev/null; do :; done
+
+  if [ -f ${RPROMPT_WORK} ] ; then
+    local lines
+    lines=( ${(@f)"$(< ${RPROMPT_WORK})"} )
+    if [[ "$lines[1]" = "$(pwd)" ]] ; then
+      RPROMPT=$lines[2]
+    fi
+    command rm -f ${RPROMPT_WORK}
+
+    # widget context here — $BUFFER / $KEYMAP reflect real zle state.
+    # Skip reset-prompt while the user is typing or selecting in a
+    # completion menu; it would otherwise clobber the display.
+    if [[ -z $BUFFER ]] && [[ $KEYMAP != "menuselect" ]]; then
+      zle reset-prompt
+    fi
   fi
 }
 
 function _async_git_stat_update {
   RPROMPT=$RPROMPT_BASE
+
+  _prompt_async_setup
 
   # fail safe to clean up dead file
   if [ -f ${RPROMPT_WORK} ] ; then
@@ -90,23 +136,6 @@ function _async_git_stat_update {
 
   if [ ! -f ${RPROMPT_WORK} ] ; then
     _git_stat_update &!
-  fi
-}
-
-function TRAPUSR2 {
-  if [ -f ${RPROMPT_WORK} ] ; then
-    lines=( ${(@f)"$(< ${RPROMPT_WORK})"} )
-    if [[ "$lines[1]" = "$(pwd)" ]] ; then
-      RPROMPT=$lines[2]
-    fi
-    command rm -f ${RPROMPT_WORK}
-
-    # Force zsh to redisplay the prompt.
-    # Skip when the user is typing or a completion menu is active,
-    # otherwise reset-prompt would clear their input/menu selection.
-    if [[ -z $BUFFER ]] && [[ $KEYMAP != "menuselect" ]]; then
-      zle && zle reset-prompt
-    fi
   fi
 }
 

--- a/lib/prompt.zsh
+++ b/lib/prompt.zsh
@@ -102,7 +102,11 @@ function TRAPUSR2 {
     command rm -f ${RPROMPT_WORK}
 
     # Force zsh to redisplay the prompt.
-    zle && zle reset-prompt
+    # Skip when the user is typing or a completion menu is active,
+    # otherwise reset-prompt would clear their input/menu selection.
+    if [[ -z $BUFFER ]] && [[ $KEYMAP != "menuselect" ]]; then
+      zle && zle reset-prompt
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary

The async git-status updater refreshes `RPROMPT` from a background
worker. When its redraw fires while the user is typing or a completion
menu is open, `zle reset-prompt` clears the input line or the menu
selection.

This PR fixes that by:

1. Guarding `zle reset-prompt` on `$BUFFER` / `$KEYMAP` state, and
2. Switching the background → foreground notification from `SIGUSR2`
   (`TRAPUSR2`) to a FIFO-backed FD monitored by `zle -F`, so the
   callback actually runs in zle widget context where those parameters
   are populated.

## Why two commits?

- **b42e5d9** added the `[[ -z $BUFFER ]] && [[ $KEYMAP != "menuselect" ]]`
  guard inside `TRAPUSR2`. That by itself **does not work**: signal-trap
  handlers are not widget context, so zle special parameters like
  `$BUFFER` are not populated and the check always evaluated as "user is
  not typing".
- **2ed70e3** replaces the signal-based notification path with a
  FIFO + `zle -F` callback. `zle -F` callbacks run in widget context,
  so the guard above now actually reflects zle state and reliably
  suppresses the redraw while the user is typing or inside a menu.

## How it works now

- On the first precmd, `_prompt_async_setup` creates a FIFO under
  `$TMPPREFIX`, opens it read+write on an auto-assigned FD
  (`exec {_prompt_async_fd}<> $fifo`), unlinks the FIFO path, and
  registers `_prompt_async_callback` via `zle -F $_prompt_async_fd`.
- The background `_git_stat_update` inherits the FD and writes one byte
  to it instead of calling `kill -s USR2 $$`.
- `_prompt_async_callback` drains buffered bytes with
  `sysread -t 0` (from `zsh/system`), applies the staged RPROMPT, and
  calls `zle reset-prompt` **only when** `$BUFFER` is empty and
  `$KEYMAP` is not `menuselect`.
- `TRAPUSR2` is removed entirely.

## Behavior

- Empty buffer, no menu → reset-prompt runs, RPROMPT updates immediately
  (unchanged from before).
- User is typing → RPROMPT value is updated but redraw is deferred;
  the next natural redraw (Enter / next keystroke triggering
  reset-prompt elsewhere) picks it up.
- Completion menu open → redraw is suppressed so the menu is not
  destroyed.

## Test

- `exec zsh` in a large repo; `cd` into it.
- Start typing immediately — input stays intact even when the git
  status arrives.
- Open a completion menu (`Tab`) and wait for an async update — menu
  stays visible.