### PR TITLE
git d-mb サブコマンドを追加

### DIFF
--- a/plugins/git/bin/git-d-mb
+++ b/plugins/git/bin/git-d-mb
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eu
+
+base_branch=""
+for branch in develop main master; do
+    if git show-ref --verify --quiet "refs/heads/$branch"; then
+        base_branch="$branch"
+        break
+    fi
+done
+
+if [ -z "$base_branch" ]; then
+    echo "❌ Error: No base branch found (develop, main, or master)." >&2
+    exit 1
+fi
+
+exec git diff "$(git merge-base "$base_branch" HEAD)" "$@"


### PR DESCRIPTION
## 概要

ベースブランチとの merge-base からの差分を確認するためのサブコマンド `git d-mb` を追加します。

## 動機

`git diff $(git merge-base develop HEAD)` を毎回打つのが煩雑なので、ワンコマンドで呼び出せるようにします。

## 仕様

- ローカルに `develop` → `main` → `master` の順で探索し、最初に見つかったブランチを base として使用
- 見つからない場合は stderr にエラーを出力し exit 1
- 追加引数は `git diff` に透過 (例: `git d-mb --stat`)
