### PR TITLE
zsh の起動を ~2.4秒 → ~0.8秒に高速化

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,7 +1,10 @@
 export ZSH_EXT_BASE=$HOME/.zsh.d
 
-autoload -U compinit
-compinit -i
+# Defer compdef calls made during lib/plugin loading until after compinit.
+# Plugins may both add to $fpath and call compdef; this stub lets compinit
+# run last (after every fpath addition) regardless of load order.
+typeset -ga _pending_compdefs
+compdef() { _pending_compdefs+=("${(j: :)${(q)@}}") }
 
 # TIP: Add files you don't want in git to .gitignore
 for config_file ($ZSH_EXT_BASE/lib/*.zsh) source $config_file
@@ -14,8 +17,6 @@ for plugin ($ZSH_EXT_BASE/plugins/*) {
   fi
 }
 
-for config_file ($ZSH_EXT_BASE/lib_after_plugin/*.zsh) source $config_file
-
 # add local_tools at the top of PATH
 export PATH=/opt/local_tools:$PATH
 
@@ -26,3 +27,18 @@ fi
 if [ -d $HOME/.local/share/zsh/site-functions ]; then
   fpath=($HOME/.local/share/zsh/site-functions $fpath)
 fi
+
+# run compinit after all fpath additions (lib, plugins, local site-functions),
+# then replay the compdef calls collected by the stub above.
+unfunction compdef
+autoload -U compinit
+if [[ -n ~/.zcompdump(#qN.mh+24) ]]; then
+  compinit -i
+else
+  compinit -C -i
+fi
+for _cd in $_pending_compdefs; do eval "compdef $_cd"; done
+unset _pending_compdefs _cd
+
+# lib_after_plugin: loaded last, after compinit and all widget setup
+for config_file ($ZSH_EXT_BASE/lib_after_plugin/*.zsh) source $config_file

--- a/lib/fzf.zsh
+++ b/lib/fzf.zsh
@@ -1,5 +1,5 @@
-export PATH=/opt/fzf/bin:$PATH
-export MANPATH=/opt/fzf/man:`manpath -q`
+export PATH=${HOMEBREW_PREFIX}/opt/fzf/bin:$PATH
+export MANPATH=${HOMEBREW_PREFIX}/opt/fzf/share/man:`manpath -q`
 
 export FZF_TMUX_HEIGHT=60
 
@@ -8,15 +8,9 @@ export FZF_TMUX_HEIGHT=60
 #   kill <TAB>
 #   cd ../**<TAB>
 #   emacs **<TAB>
-if [ -f /opt/fzf/shell/completion.zsh ]; then
-  source /opt/fzf/shell/completion.zsh
+if [ -f ${HOMEBREW_PREFIX}/opt/fzf/shell/completion.zsh ]; then
+  source ${HOMEBREW_PREFIX}/opt/fzf/shell/completion.zsh
 fi
-
-case ${OSTYPE} in
-  darwin*)
-    source $(brew ls fzf | grep --color=no shell | grep --color=no completion.zsh)
-  ;;
-esac
 
 export FZF_DEFAULT_OPTS='--border --ansi --reverse --exit-0'
 export FZF_DEFAULT_OPTS=$FZF_DEFAULT_OPTS' --color=fg:000000,bg:#ffffff,hl:#177899 --color=fg+:#ffffff,bg+:#008cd7,hl+:#adebff --color=info:#afaf87,prompt:#cc0058,pointer:#d5abff --color=marker:#77e304,spinner:#a64cff,header:#87afaf'

--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -52,8 +52,8 @@ esac
 fpath=(~/.zsh.d/plugins/zsh-completions/src $fpath)
 fpath=(/usr/local/share/zsh/site-functions $fpath)
 
-# syntax highliting
-source $HOME/.zsh.d/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+# syntax highlighting is sourced from lib_after_plugin/ so it loads after
+# compinit and all widget definitions (it must wrap existing ZLE widgets)
 
 EZA_COLORS="uu=38;5;124:ux=38;5;30:ue=38;5;30:ur=38;5;124:uw=38;5;160"
 EZA_COLORS+=":gu=38;5;172"

--- a/lib_after_plugin/zsh-syntax-highlighting.zsh
+++ b/lib_after_plugin/zsh-syntax-highlighting.zsh
@@ -1,0 +1,3 @@
+# Must be sourced last: zsh-syntax-highlighting wraps existing ZLE widgets,
+# so it has to run after compinit and any other widget/keybinding setup.
+source $HOME/.zsh.d/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh


### PR DESCRIPTION
## 概要

zsh の起動時間が ~2.4 秒と遅かったため、ボトルネックを計測して最適化した。起動 **~2.4秒 → ~0.8秒**(約3倍速)。

## ボトルネック(計測結果)

| 箇所 | 時間 | 原因 |
|---|---|---|
| `lib/fzf.zsh` | ~1700ms | `source $(brew ls fzf ...)` の `brew ls fzf` が単体で約1秒 |
| `compinit` | ~800ms | キャッシュ未使用で毎回 `compaudit` がディスク全走査 |

## 変更内容

### `lib/fzf.zsh`
- `brew ls fzf` を廃止し、`${HOMEBREW_PREFIX}/opt/fzf/` を直接参照(PATH / MANPATH / completion.zsh)
- 実在しなかった `/opt/fzf` 用ブロックを削除

### `init.sh`
- `compinit` をキャッシュ利用に変更(`.zcompdump` が24時間以内なら `compinit -C`)
- `compinit` を全ての `fpath` 追加(lib / plugins / local site-functions)の後に移動し、プラグインの補完が確実に拾われるようにした
- プラグインが source 時に呼ぶ `compdef` を一旦バッファに貯め、`compinit` 後にまとめて再生する stub を追加。これによりプラグインのロード順に依存しなくなった

### `zsh-syntax-highlighting` の移動
- `lib/misc.zsh` 内の source を `lib_after_plugin/zsh-syntax-highlighting.zsh` へ移動
- `compinit` と全ウィジェット定義の後にロードされるようになり、推奨されるロード順(最後尾)になった

## 動作確認

- `source ~/.zshrc` 再読み込み OK
- 補完(`sshcode` / `gem` / `git`)、fzf、syntax-highlighting、キーバインドすべて正常
- 起動時間 ~0.8 秒で安定(初回 `.zcompdump` 再生成時のみ ~1.5秒)