### PR TITLE
Claude Code statuslineのモデル非表示設定を削除

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -93,6 +93,3 @@ function copy_basename() {
 
 # use custom emacs
 export PATH=/opt/emacs/bin:${PATH}
-
-# claude
-export CC_STATUSLINE_NO_MODEL=1


### PR DESCRIPTION
## 概要

`lib/misc.zsh` から `CC_STATUSLINE_NO_MODEL=1` の環境変数 export を削除しました。

## 変更内容

- `CC_STATUSLINE_NO_MODEL=1` の export と関連コメントを削除

## 理由

この環境変数は不要になったため削除します。これにより Claude Code のステータスラインにモデル名が再び表示されるようになります。