### PR TITLE
cdr履歴の非同期クリーンアップとロックによる書き込み直列化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.vscode
 .DS_Store
+/doc

--- a/lib/cdr.zsh
+++ b/lib/cdr.zsh
@@ -2,4 +2,101 @@ autoload -Uz chpwd_recent_dirs cdr add-zsh-hook
 zstyle ':completion:*' recent-dirs-insert both
 zstyle ':chpwd:*' recent-dirs-max 5000
 zstyle ':chpwd:*' recent-dirs-default true
-add-zsh-hook chpwd chpwd_recent_dirs
+
+# cdr の履歴ファイルとロックファイル。
+# recent-dirs-file style は未設定なので cdr 本体と同じデフォルトに合わせる。
+__CDR_FILE="${ZDOTDIR:-$HOME}/.chpwd-recent-dirs"
+__CDR_LOCK="${__CDR_FILE}.lock"
+# ロックファイルが作成からこの秒数以上経過していたら、異常終了などで残った
+# stale なロックとみなす（30 分）。ロックファイルには一切書き込まないため
+# mtime = 作成日時のままなので、mtime の経過時間で判定できる。
+__CDR_LOCK_STALE_SEC=1800
+
+# zsystem flock -f <var> <file> はファイルを O_CREAT では開かない（無いと失敗する）
+# ため、あらかじめ空のロックファイルを用意しておく。
+# 作成に使う「: >> file」はコマンド終了時に fd を閉じるので、exec による
+# オープンと違い fd をリークしない。
+[[ -e $__CDR_LOCK ]] || : >> "$__CDR_LOCK" 2>/dev/null
+
+# ロックを取得し、成功したらグローバル __cdr_fd に fd をセットして 0 を返す。
+# timeout 秒だけ待つ。-i 0.01 で 10ms 間隔でポーリングする
+# （-i 省略時は既定 1 秒間隔になり、多重競合時に取りこぼしてタイムアウトする）。
+# ロックファイルが stale 削除などで消えていれば作り直す。
+__cdr_flock() {
+  __cdr_fd=''
+  [[ -e $__CDR_LOCK ]] || : >> "$__CDR_LOCK" 2>/dev/null
+  zsystem flock -t "$1" -i 0.01 -f __cdr_fd "$__CDR_LOCK" 2>/dev/null
+}
+
+# cd 時の履歴書き込み（chpwd_recent_dirs）をロックで直列化するラッパー。
+#
+# chpwd_recent_dirs は read-modify-write を「> file」で非アトミックかつ
+# 無ロックに行うため、prepare-tmux のように複数シェルが同時に cd すると
+# 上書き競合で履歴が失われる（実測: 25 シェル同時で数件ロスト）。
+# 読み込み〜書き込みの全体を flock で囲むことで欠損をなくす。
+__cdr_chpwd() {
+  emulate -L zsh
+  zmodload -F zsh/system b:zsystem 2>/dev/null || { chpwd_recent_dirs; return }
+
+  # 通常はここで取得できる（最大 5 秒待つ）。
+  if ! __cdr_flock 5; then
+    # 取得できない = 誰かが保持中。ただしロックファイルが作成から 30 分以上
+    # 経過していれば、異常終了/ハングで放置された持ち主とみなして削除し、
+    # 作り直して取り直す。正常な保持はミリ秒で解放されるのでここには来ない。
+    if [[ -n ${__CDR_LOCK}(Nms+${__CDR_LOCK_STALE_SEC}) ]]; then
+      rm -f -- "$__CDR_LOCK"
+      __cdr_flock 5
+    fi
+  fi
+
+  if [[ -n $__cdr_fd ]]; then
+    # try/always: どの経路で抜けても必ず fd を閉じてロックを解放する。
+    { chpwd_recent_dirs } always { exec {__cdr_fd}>&- }
+  else
+    # それでも取れなければ従来どおり書く（デッドロックだけは避ける）。
+    chpwd_recent_dirs
+  fi
+}
+add-zsh-hook chpwd __cdr_chpwd
+
+# cdr 履歴ファイルから存在しないディレクトリを取り除く。
+# 上と同じロックを共有し、tmp への書き出し + 原子的 rename で置換するので、
+# 複数シェル同時起動でも上書き競合・履歴消失は起きない。
+__cdr_prune_recent_dirs() {
+  emulate -L zsh
+  setopt no_nomatch no_unset
+
+  [[ -r $__CDR_FILE ]] || return 0
+  zmodload -F zsh/system b:zsystem 2>/dev/null || return 0
+
+  # cd 書き込みや他の prune が走っていれば（非ブロッキングで取得失敗）何もしない。
+  # prune は取りこぼしても次回また走るので待つ必要はない。
+  __cdr_flock 0 || return 0
+
+  local tmp="${__CDR_FILE}.tmp.$$"
+  local line dir
+  # try/always: 途中で return・エラー・シグナルのいずれで抜けても
+  # 必ず fd を閉じて（＝ロック解放）tmp を後始末する。
+  {
+    : > "$tmp" || return 0
+    while IFS= read -r line; do
+      [[ -n $line ]] || continue
+      # 各行は $'...' 形式なので eval で実パスへ復号する
+      eval "dir=$line"
+      [[ -d $dir ]] && print -r -- "$line" >> "$tmp"
+    done < "$__CDR_FILE"
+    mv -f "$tmp" "$__CDR_FILE" 2>/dev/null
+  } always {
+    [[ -e $tmp ]] && rm -f "$tmp"
+    exec {__cdr_fd}>&-
+  }
+}
+
+# cd のたびに実行する必要はないので、確率的に（およそ 1/500）
+# バックグラウンドで起動する。&! でジョブを切り離し、
+# プロンプト表示をブロックしない。
+__cdr_prune_recent_dirs_maybe() {
+  (( RANDOM % 500 == 0 )) || return 0
+  __cdr_prune_recent_dirs &!
+}
+add-zsh-hook chpwd __cdr_prune_recent_dirs_maybe

--- a/lib/cdr.zsh
+++ b/lib/cdr.zsh
@@ -3,14 +3,17 @@ zstyle ':completion:*' recent-dirs-insert both
 zstyle ':chpwd:*' recent-dirs-max 5000
 zstyle ':chpwd:*' recent-dirs-default true
 
-# cdr の履歴ファイルとロックファイル。
+# cdr の履歴ファイルとロックファイル。意図的なグローバルであることを typeset -g で
+# 明示する（readonly は付けない: 設定を再ソースすると read-only エラーになるため）。
 # recent-dirs-file style は未設定なので cdr 本体と同じデフォルトに合わせる。
-__CDR_FILE="${ZDOTDIR:-$HOME}/.chpwd-recent-dirs"
-__CDR_LOCK="${__CDR_FILE}.lock"
+typeset -g __CDR_FILE="${ZDOTDIR:-$HOME}/.chpwd-recent-dirs"
+typeset -g __CDR_LOCK="${__CDR_FILE}.lock"
 # ロックファイルが作成からこの秒数以上経過していたら、異常終了などで残った
 # stale なロックとみなす（30 分）。ロックファイルには一切書き込まないため
 # mtime = 作成日時のままなので、mtime の経過時間で判定できる。
-__CDR_LOCK_STALE_SEC=1800
+typeset -gi __CDR_LOCK_STALE_SEC=1800
+# ロック取得に成功した fd を入れるグローバル（__cdr_flock がセットする）。
+typeset -g __cdr_fd=''
 
 # zsystem flock -f <var> <file> はファイルを O_CREAT では開かない（無いと失敗する）
 # ため、あらかじめ空のロックファイルを用意しておく。

--- a/lib/cdr.zsh
+++ b/lib/cdr.zsh
@@ -5,8 +5,22 @@ zstyle ':chpwd:*' recent-dirs-default true
 
 # cdr の履歴ファイルとロックファイル。意図的なグローバルであることを typeset -g で
 # 明示する（readonly は付けない: 設定を再ソースすると read-only エラーになるため）。
-# recent-dirs-file style は未設定なので cdr 本体と同じデフォルトに合わせる。
-typeset -g __CDR_FILE="${ZDOTDIR:-$HOME}/.chpwd-recent-dirs"
+#
+# 履歴ファイルのパスは cdr 本体（chpwd_recent_filehandler）と同じ手順で解決する:
+# recent-dirs-file style があればそれを使い（"+" はデフォルトに展開）、無ければ
+# ${ZDOTDIR:-$HOME}/.chpwd-recent-dirs を使う。書き込み先は先頭要素 files[1]。
+# style はここで評価するので、recent-dirs-file を使う場合は上の zstyle 群と
+# 一緒に（この行より前で）設定すること。
+typeset -g __CDR_FILE
+() {
+  emulate -L zsh
+  setopt extended_glob
+  local default=${ZDOTDIR:-$HOME}/.chpwd-recent-dirs
+  local -a files
+  zstyle -a ':chpwd:' recent-dirs-file files && files=(${files//(#s)+(#e)/$default})
+  (( ${#files} )) || files=($default)
+  __CDR_FILE=${files[1]}
+}
 typeset -g __CDR_LOCK="${__CDR_FILE}.lock"
 # ロックファイルが作成からこの秒数以上経過していたら、異常終了などで残った
 # stale なロックとみなす（30 分）。ロックファイルには一切書き込まないため

--- a/lib/cdr.zsh
+++ b/lib/cdr.zsh
@@ -75,14 +75,17 @@ __cdr_prune_recent_dirs() {
 
   local tmp="${__CDR_FILE}.tmp.$$"
   local line dir
+  local -a parts
   # try/always: 途中で return・エラー・シグナルのいずれで抜けても
   # 必ず fd を閉じて（＝ロック解放）tmp を後始末する。
   {
     : > "$tmp" || return 0
     while IFS= read -r line; do
       [[ -n $line ]] || continue
-      # 各行は $'...' 形式なので eval で実パスへ復号する
-      eval "dir=$line"
+      # 各行は $'...' 形式。cdr 本体（chpwd_recent_filehandler）と同じく
+      # (z) で分割し (Q) で引用符を外して実パスへ復号する（eval は使わない）。
+      parts=(${(z)line})
+      dir=${(Q)${parts[1]:-}}
       [[ -d $dir ]] && print -r -- "$line" >> "$tmp"
     done < "$__CDR_FILE"
     mv -f "$tmp" "$__CDR_FILE" 2>/dev/null

--- a/lib/fzf.zsh
+++ b/lib/fzf.zsh
@@ -32,9 +32,9 @@ __fzfcmd() {
 
 # CTRL-G C for cdr
 function fzf-cdr () {
-  # 履歴は消さず、表示時に「今 存在するディレクトリ」だけに絞る（~ 表記は保持）
+  # 存在チェックは表示時に行わず、cdr の履歴をそのまま全件表示する（高速）。
+  # 存在しないディレクトリの掃除は cd 時に非同期で行う（lib/cdr.zsh 参照）。
   local selected_dir=$(cdr -l | awk '{ print $2 }' \
-    | while IFS= read -r d; do [[ -d ${d/#\~/$HOME} ]] && print -r -- "$d"; done \
     | $(__fzfcmd) --query "$LBUFFER")
   if [ -n "$selected_dir" ]; then
     BUFFER="cd ${selected_dir}"


### PR DESCRIPTION
## 概要

`cdr` のディレクトリ履歴が増えて `fzf-cdr` の表示が遅くなっていた問題と、複数シェル同時起動時に履歴が失われる問題をまとめて修正します。

## 背景 / 課題

- `cdr -l` の履歴が 126 件まで増え、`fzf-cdr` が**表示のたびに全件を同期で存在チェック**していたため遅くなっていた。
- `chpwd_recent_dirs`（cdr 本体）は履歴ファイルを**無ロックの `>` で全上書き**するため、`prepare-tmux` のように複数シェルが同時に `cd` すると上書き競合で履歴が失われていた（実測: 25 シェル同時で数件ロスト）。

## 変更内容

- **`fzf-cdr`（lib/fzf.zsh）**: 表示時の存在チェックを廃止し、`cdr -l` を全件そのまま表示（高速化）。存在しない dir の掃除は cd 時に非同期で行う。
- **非同期クリーンアップ（lib/cdr.zsh）**: `cd` のたび **約 1/500** の確率でバックグラウンド（`&!`）起動し、存在しないディレクトリを履歴から除去。`tmp` へ書き出し + 原子的 `rename` で置換。
- **書き込みの直列化**: `chpwd_recent_dirs` の read-modify-write 全体と掃除処理を**共有 flock** で直列化し、同時起動時の履歴欠損をゼロに（実測 25/25）。
- **stale ロック回復**: ロック取得に失敗し、かつロックファイルが**作成から 30 分以上経過**していれば、放置された持ち主とみなして削除・再取得。デッドロックは最大 5 秒でフォールバックして回避。

## 検証

- 通常の cd 記録: 正常
- 25 シェル同時 cd: **25/25**（3 回連続、修正前は 18〜23/25）
- prune: 存在しない dir を除去
- stale 回復 / 非 stale 時の保持者尊重: いずれも期待どおり
- fd リークなし（`zsystem flock -f` 単独 + `: >>` での作成）

## レビュアーへの注意点

- flock は `zsh/system` の `zsystem flock` を使用。`-i 0.01` は多重競合時の取りこぼし防止（既定 1 秒間隔だとタイムアウトする）。
- `zsystem flock -f` は `O_CREAT` しないため、ロックファイルを事前に `: >>` で作成しています。